### PR TITLE
Add news summary page

### DIFF
--- a/public/news.json
+++ b/public/news.json
@@ -1,0 +1,25 @@
+{
+  "date": "2025-06-05",
+  "articles": [
+    {
+      "title": "Global markets rally as economic outlook improves",
+      "summary": "Stocks rose worldwide after new data pointed to a faster than expected recovery."
+    },
+    {
+      "title": "Scientists announce breakthrough in renewable energy",
+      "summary": "A new technology promises to make solar cells much cheaper."
+    },
+    {
+      "title": "Major tech conference highlights AI developments",
+      "summary": "Companies showcased new generative AI tools at the annual event."
+    },
+    {
+      "title": "Historic peace agreement signed by rival nations",
+      "summary": "Leaders hailed the accord as a new era of cooperation in the region."
+    },
+    {
+      "title": "Researchers find link between diet and longevity",
+      "summary": "A long-term study suggests whole grains could boost life expectancy."
+    }
+  ]
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import Events from "./pages/Events";
+import News from "./pages/News";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -19,6 +20,7 @@ const App = () => (
         <Routes>
           <Route path="/" element={<Index />} />
           <Route path="/events" element={<Events />} />
+          <Route path="/news" element={<News />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </BrowserRouter>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -16,11 +16,19 @@ const Index = () => {
           New Client
         </ActionButton>
         
-        <ActionButton 
+
+        <ActionButton
           className="bg-gray-900 text-white hover:bg-gray-800"
           onClick={() => navigate("/events")}
         >
           Trigger Events
+        </ActionButton>
+
+        <ActionButton
+          className="bg-gray-100 text-gray-900 hover:bg-gray-200"
+          onClick={() => navigate("/news")}
+        >
+          News Today
         </ActionButton>
         
         <ActionButton className="bg-gray-100 text-gray-900 hover:bg-gray-200">

--- a/src/pages/News.tsx
+++ b/src/pages/News.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import Card from "@/components/Card";
+import ActionButton from "@/components/ActionButton";
+import { useNavigate } from "react-router-dom";
+
+interface Article {
+  title: string;
+  summary: string;
+}
+
+const News = () => {
+  const navigate = useNavigate();
+  const [articles, setArticles] = useState<Article[]>([]);
+
+  useEffect(() => {
+    fetch("/news.json")
+      .then((res) => res.json())
+      .then((data) => setArticles(data.articles))
+      .catch((err) => console.error("Failed to load news", err));
+  }, []);
+
+  return (
+    <div className="min-h-screen p-6 space-y-8 max-w-3xl mx-auto page-transition">
+      <div className="flex items-center space-x-4">
+        <button
+          onClick={() => navigate("/")}
+          className="text-gray-600 hover:text-gray-900 transition-colors"
+        >
+          ← Back
+        </button>
+        <h1 className="text-3xl font-bold text-gray-900">Today's News Summary</h1>
+      </div>
+
+      <div className="space-y-6">
+        {articles.map((article, idx) => (
+          <Card key={idx}>
+            <h2 className="text-xl font-semibold mb-2">{article.title}</h2>
+            <p className="text-gray-700 mb-4">{article.summary}</p>
+          </Card>
+        ))}
+        {articles.length === 0 && (
+          <p className="text-gray-600">Loading news...</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default News;


### PR DESCRIPTION
## Summary
- fetch articles from `public/news.json` and show them in a new `News` page
- route `/news` in the app
- add button on the index page to access the news summary

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype)*

------
https://chatgpt.com/codex/tasks/task_e_6841a6df76fc8322ae17a42be9edd3d8