### PR TITLE
Fix news page fetch path

### DIFF
--- a/src/pages/News.tsx
+++ b/src/pages/News.tsx
@@ -13,7 +13,8 @@ const News = () => {
   const [articles, setArticles] = useState<Article[]>([]);
 
   useEffect(() => {
-    fetch("/news.json")
+    const url = `${import.meta.env.BASE_URL}news.json`;
+    fetch(url)
       .then((res) => res.json())
       .then((data) => setArticles(data.articles))
       .catch((err) => console.error("Failed to load news", err));


### PR DESCRIPTION
## Summary
- fix news fetch path to respect Vite base URL

## Testing
- `npm run lint` *(fails: cannot satisfy existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841a9ab3f548322b51cf92225b35abb